### PR TITLE
Pin to steam sdk 3.0.20250826.159138 and rustc 1.89.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-from registry.gitlab.steamos.cloud/steamrt/sniper/sdk:latest
+from registry.gitlab.steamos.cloud/steamrt/sniper/sdk:3.0.20250826.159138
 
 ENV OUTPUT_DIR=/output
 ENV DATA_DIR=/data
@@ -6,7 +6,7 @@ ENV SRC_DIR=/src
 
 COPY --chmod=755 ./builder.sh /builder.sh
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- '-y'
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.89.0 -y
 RUN apt update
 RUN apt install -y libudev-dev lld librust-bzip2-dev
 RUN mkdir $OUTPUT_DIR


### PR DESCRIPTION
Changed from using "latest" for Steam SDK and rustc to specify the versions & remove ambiguity from image builds + improve reliability for reproducible builds